### PR TITLE
Swing worker

### DIFF
--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/Activator.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/Activator.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer;
 
 import org.orbisgis.mapcomposer.controller.UIController;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/Activator.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/Activator.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -30,6 +33,8 @@ import org.osgi.framework.BundleContext;
 
 /**
  * Registers services provided by this plugin bundle.
+ *
+ * @author Sylvain PALOMINOS
  */
 public class Activator implements BundleActivator {
         /**

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -70,6 +73,8 @@ import org.xml.sax.SAXException;
 
 /**
  * This class manager the interaction between the MainWindows, the CompositionArea and and the data model.
+ *
+ * @author Sylvain PALOMINOS
  */
 public class UIController{
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
@@ -97,7 +97,10 @@ public class UIController{
         zIndexStack = new Stack<>();
         saveNLoadHandler = new SaveAndLoadHandler(geManager, caManager);
         mainWindow = new MainWindow(this);
+        mainWindow.setLocationRelativeTo(null);
         executorService = Executors.newFixedThreadPool(1);
+
+        UIFactory.setMainFrame(mainWindow);
     }
 
     /**
@@ -696,6 +699,7 @@ public class UIController{
         dialog.setVisible(true);
         dialog.pack();
         dialog.setAlwaysOnTop(true);
+        dialog.setLocationRelativeTo(mainWindow);
         return dialog;
     }
     

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
@@ -396,7 +396,7 @@ public class UIController{
                         BufferedImage bi = ImageIO.read(new File(((SimpleIllustrationGE) newGE).getPath()));
                         mainWindow.getCompositionArea().getOverlay().setRatio((float) bi.getWidth() / bi.getHeight());
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        LoggerFactory.getLogger(UIController.class).error(e.getMessage());
                     }
                 }
             }
@@ -541,7 +541,7 @@ public class UIController{
                             BufferedImage bi = ImageIO.read(f);
                             mainWindow.getCompositionArea().getOverlay().setRatio((float) bi.getWidth() / bi.getHeight());
                         } catch (IOException e) {
-                            e.printStackTrace();
+                            LoggerFactory.getLogger(UIController.class).error(e.getMessage());
                         }
                     }
                 }

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
@@ -27,6 +27,7 @@ import java.util.logging.Logger;
 import javax.imageio.ImageIO;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.orbisgis.mapcomposer.view.utils.RenderWorker;
 import org.orbisgis.mapcomposer.view.utils.UIDialogProperties;
 import org.orbisgis.sif.SIFDialog;
 import org.orbisgis.sif.UIFactory;
@@ -292,7 +293,8 @@ public class UIController{
     public void validateGE(GraphicalElement ge){
         if(ge instanceof GERefresh)
             ((GERefresh)ge).refresh();
-        elementJPanelMap.get(ge).setPanelContent(geManager.getRenderer(ge.getClass()).createImageFromGE(ge));
+        RenderWorker worker = new RenderWorker(this, elementJPanelMap.get(ge), geManager.getRenderer(ge.getClass()), ge);
+        worker.execute();
         if(ge instanceof Document)
             mainWindow.getCompositionArea().setDocumentDimension(new Dimension(ge.getWidth(), ge.getHeight()));
         refreshSpin();
@@ -425,7 +427,8 @@ public class UIController{
         if(ge instanceof GERefresh){
             ((GERefresh)ge).refresh();
         }
-        elementJPanelMap.get(ge).setPanelContent(geManager.getRenderer(ge.getClass()).createImageFromGE(ge));
+        RenderWorker worker = new RenderWorker(this, elementJPanelMap.get(ge), geManager.getRenderer(ge.getClass()), ge);
+        worker.execute();
         zIndexStack.push(ge);
         //Apply the z-index change to only the GraphicalElement ge.
         List temp = selectedGE;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
@@ -93,6 +93,17 @@ public class UIController{
         mainWindow = new MainWindow(this);
         executorService = Executors.newFixedThreadPool(1);
     }
+
+    /**
+     * Returns true if the CompositionArea already contain a Document GE, false otherwise.
+     * @return true if a document GE exist, false otherwise.
+     */
+    public boolean isDocumentCreated(){
+        for(GraphicalElement ge : elementJPanelMap.keySet())
+            if(ge instanceof Document)
+                return true;
+        return false;
+    }
     
     public MainWindow getMainWindow() { return mainWindow; }
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
@@ -543,6 +543,7 @@ public class UIController{
             newGE.setWidth(width);
             newGE.setHeight(height);
             addGE(newGE);
+            redrawGE(newGE);
         }
         mainWindow.getCompositionArea().setOverlayMode(CompositionAreaOverlay.Mode.NONE);
         newGE=null;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
@@ -672,7 +672,7 @@ public class UIController{
     public SIFDialog showGEProperties(GraphicalElement ge){
         toBeSet.add(ge);
         //Create and show the properties dialog.
-        UIPanel panel = new UIDialogProperties(getCommonAttributes(), this, false);
+        UIPanel panel = new UIDialogProperties(ge.getAllAttributes(), this, false);
         SIFDialog dialog = UIFactory.getSimpleDialog(panel, mainWindow, true);
         dialog.setVisible(true);
         dialog.pack();

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
@@ -2,6 +2,7 @@ package org.orbisgis.mapcomposer.controller;
 
 import static java.lang.Math.cos;
 import static java.lang.Math.sin;
+
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute;
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.RefreshCA;
 import org.orbisgis.mapcomposer.model.configurationattribute.utils.CAManager;
@@ -17,10 +18,16 @@ import org.orbisgis.mapcomposer.model.utils.SaveAndLoadHandler;
 import org.orbisgis.mapcomposer.view.ui.MainWindow;
 import org.orbisgis.mapcomposer.view.utils.CompositionAreaOverlay;
 import org.orbisgis.mapcomposer.view.utils.CompositionJPanel;
+import org.orbisgis.mapcomposer.view.utils.RenderWorker;
+import org.orbisgis.mapcomposer.view.utils.UIDialogProperties;
+import org.orbisgis.sif.SIFDialog;
+import org.orbisgis.sif.UIFactory;
+import org.orbisgis.sif.UIPanel;
+import org.orbisgis.sif.components.SaveFilePanel;
+
 import java.awt.Dimension;
 import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
-import java.awt.event.WindowStateListener;
 import java.awt.image.BufferedImage;
 import java.beans.EventHandler;
 import java.beans.PropertyChangeEvent;
@@ -32,16 +39,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import javax.imageio.ImageIO;
 import javax.swing.*;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.orbisgis.mapcomposer.view.utils.RenderWorker;
-import org.orbisgis.mapcomposer.view.utils.UIDialogProperties;
-import org.orbisgis.sif.SIFDialog;
-import org.orbisgis.sif.UIFactory;
-import org.orbisgis.sif.UIPanel;
-import org.orbisgis.sif.components.SaveFilePanel;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
@@ -689,7 +689,8 @@ public class UIController{
     }
 
     /**
-     * Open a dialog window with all the ConfigurationAttributes from the given GraphicalElement.
+     * Open and return a dialog window with all the ConfigurationAttributes from the given GraphicalElement.
+     * @return The configuration dialog.
      */
     public SIFDialog showGEProperties(GraphicalElement ge){
         toBeSet.add(ge);
@@ -784,6 +785,8 @@ public class UIController{
             lastRenderWorker.addPropertyChangeListener(new PropertyChangeListener() {
                 @Override
                 public void propertyChange(PropertyChangeEvent propertyChangeEvent) {
+                    //Reset the executorService
+                    executorService = Executors.newFixedThreadPool(1);
                     //Verify if the property state is at DONE
                     if (propertyChangeEvent.getNewValue().equals(SwingWorker.StateValue.DONE)) {
                         //Creates and sets the file chooser

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
@@ -237,17 +237,24 @@ public class UIController{
     }
 
     /**
-     * Refresh the JSpinner value with the value from the selected GE.
+     * Refreshes the JSpinner value and state (enable or not) with the values from the selected GEs.
+     * The method test each GraphicalElement from the selectedGE list to know if every single GE property (X and Y position, width, height, rotation) is the same for the GEs.
+     * In the case where a property is the same for all the selected GE, the corresponding spinner is set to the common value and enabled.
+     * In the case where a property is different for the selected GE, the corresponding spinner is set to 0 and disabled.
+     * In the case where no GE are selected, all the spinners are set to 0 and disabled.
      */
     public void refreshSpin(){
+        //Set the default state for the spinner (enabled and value to 0).
         boolean boolX=false, boolY=false, boolW=false, boolH=false, boolR=false;
-        int x=0, y=0, w=0, h=0, r=0; 
+        int x=0, y=0, w=0, h=0, r=0;
+        //If GEs are selected, test each
         if(!selectedGE.isEmpty()){
             x=selectedGE.get(0).getX();
             y=selectedGE.get(0).getY();
             w=selectedGE.get(0).getWidth();
             h=selectedGE.get(0).getHeight();
             r=selectedGE.get(0).getRotation();
+            //Test each GE
             for(GraphicalElement graph : selectedGE){
                 if(x!=graph.getX()){ boolX=true;x=selectedGE.get(0).getX();}
                 if(y!=graph.getY()){ boolY=true;y=selectedGE.get(0).getY();}
@@ -256,6 +263,15 @@ public class UIController{
                 if(r!=graph.getRotation()){ boolR=true;r=selectedGE.get(0).getRotation();}
             }
         }
+        //If no GE are selected, lock all the spinners
+        else {
+            boolX = true;
+            boolY = true;
+            boolW = true;
+            boolH = true;
+            boolR = true;
+        }
+        //Sets the spinners.
         mainWindow.setSpinner(boolX, x, Property.X);
         mainWindow.setSpinner(boolY, y, Property.Y);
         mainWindow.setSpinner(boolW, w, Property.WIDTH);

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.controller;
 
 import static java.lang.Math.cos;
@@ -261,7 +282,7 @@ public class UIController{
             r=selectedGE.get(0).getRotation();
             //Test each GE
             for(GraphicalElement graph : selectedGE){
-                if(x!=graph.getX()){ boolX=true;x=selectedGE.get(0).getX();}
+                if (x != graph.getX()){ boolX=true;x=selectedGE.get(0).getX();}
                 if(y!=graph.getY()){ boolY=true;y=selectedGE.get(0).getY();}
                 if(w!=graph.getWidth()){ boolW=true;w=selectedGE.get(0).getWidth();}
                 if(h!=graph.getHeight()){ boolH=true;h=selectedGE.get(0).getHeight();}
@@ -363,7 +384,7 @@ public class UIController{
             ((GERefresh)ge).refresh();
         unselectGE(ge);
         RenderWorker worker = new RenderWorker(elementJPanelMap.get(ge), geManager.getRenderer(ge.getClass()), ge);
-        worker.execute();
+        executorService.submit(worker);
         if(ge instanceof Document)
             mainWindow.getCompositionArea().setDocumentDimension(new Dimension(ge.getWidth(), ge.getHeight()));
         refreshSpin();
@@ -731,7 +752,7 @@ public class UIController{
     public enum ZIndex{
         TO_FRONT, FRONT, BACK, TO_BACK;
     }
-    
+
     public enum Align{
         LEFT, CENTER, RIGHT, TOP, MIDDLE, BOTTOM;
     }

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
@@ -519,7 +519,7 @@ public class UIController{
                 if(ca instanceof RefreshCA)
                     ((RefreshCA)ca).refresh(this);
 
-            showGEProperties(newGE).addWindowListener(EventHandler.create(WindowListener.class, this, "drawGE", "", "windowClosed"));;
+            showGEProperties(newGE).addWindowListener(EventHandler.create(WindowListener.class, this, "drawGE", "", "windowClosed"));
         } catch (InstantiationException | IllegalAccessException ex) {
             LoggerFactory.getLogger(UIController.class).error(ex.getMessage());
         }
@@ -530,7 +530,7 @@ public class UIController{
      * @param winEvent
      */
     public void drawGE(WindowEvent winEvent){
-        if(winEvent.getSource() instanceof SIFDialog) {
+        if(winEvent.getSource() instanceof SIFDialog && newGE != null) {
             SIFDialog sifDialog = (SIFDialog) winEvent.getSource();
             if(sifDialog.isAccepted()) {
                 //If the image has an already set path value, get the image ratio

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
@@ -199,7 +199,7 @@ public class UIController{
         for(GraphicalElement ge : zIndexStack){
             mainWindow.getCompositionArea().setZIndex(elementJPanelMap.get(ge), zIndexStack.indexOf(ge));
         }
-        validateSelectedGE();
+        modifySelectedGE();
     }
     
     /**
@@ -278,19 +278,43 @@ public class UIController{
     }
 
     /**
-     * Validates all the selected GraphicalElements
+     * Modify the position and size of all the selected GraphicalElements
      */
-    public void validateSelectedGE(){
+    public void modifySelectedGE(){
         for(GraphicalElement ge : selectedGE)
-            validateGE(ge);
+            modifyGE(ge);
     }
 
     /**
-     * Validates the given GraphicalElement.
-     * It does the refresh of the GE, the actualization of the GE representation in the CompositionArea and refreshes the spinner state.
+     * modify the position and the size of the given GraphicalElement.
+     * It does the refresh of the GE, the resizing of the GE representation in the CompositionArea and refreshes the spinner state.
+     * The GE representation is just moved and scaled, not completely re-renderer.
      * @param ge GraphicalElement to validate
      */
-    public void validateGE(GraphicalElement ge){
+    public void modifyGE(GraphicalElement ge){
+        if(ge instanceof GERefresh)
+            ((GERefresh)ge).refresh();
+        elementJPanelMap.get(ge).modify(ge.getX(), ge.getY(), ge.getWidth(), ge.getHeight(), ge.getRotation());
+        if(ge instanceof Document)
+            mainWindow.getCompositionArea().setDocumentDimension(new Dimension(ge.getWidth(), ge.getHeight()));
+        refreshSpin();
+    }
+
+    /**
+     * Redraws all the selected GraphicalElements
+     */
+    public void redrawSelectedGE(){
+        for(GraphicalElement ge : selectedGE)
+            redrawGE(ge);
+    }
+
+    /**
+     * Redraws the given GraphicalElement.
+     * It does the refresh of the GE, the actualization of the GE representation in the CompositionArea and refreshes the spinner state.
+     * The GE representation is completely re-renderer.
+     * @param ge GraphicalElement to validate
+     */
+    public void redrawGE(GraphicalElement ge){
         if(ge instanceof GERefresh)
             ((GERefresh)ge).refresh();
         RenderWorker worker = new RenderWorker(this, elementJPanelMap.get(ge), geManager.getRenderer(ge.getClass()), ge);
@@ -318,7 +342,7 @@ public class UIController{
             }
             //If the GraphicalElement was already added to the document
             if(elementJPanelMap.containsKey(ge))
-                validateGE(ge);
+                redrawGE(ge);
             //Set the CompositionAreaOverlay ratio in the case of the GraphicalElement was not already added to the Document
             else{
                 //Give the ratio to the CompositionAreaOverlay();
@@ -583,7 +607,7 @@ public class UIController{
                     }
                     break;
             }
-            validateSelectedGE();
+            modifySelectedGE();
         }
     }
 
@@ -674,7 +698,7 @@ public class UIController{
                     break;
             }
         }
-        validateSelectedGE();
+        modifySelectedGE();
     }
     
     /**

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/BaseCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/BaseCA.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -30,6 +33,8 @@ import java.util.Map;
  * This class implements the ConfigurationAttribute (CA) interface and is a base for the natives CA.
  * All the methods implemented are common for each native CA.
  * It can also be used as a base to develop custom CA.
+ *
+ * @author Sylvain PALOMINOS
  */
 public abstract class BaseCA<T> implements ConfigurationAttribute<T>{
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/BaseCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/BaseCA.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.configurationattribute.attribute;
 
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/BaseListCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/BaseListCA.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.configurationattribute.attribute;
 
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/BaseListCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/BaseListCA.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -31,6 +34,8 @@ import java.util.Map;
  * This class implements the ListCA (listCA) interface and is a base for the natives listCA.
  * All the methods implemented are common for each native listCA.
  * It can also be used as a base to develop custom listCA.
+ *
+ * @author Sylvain PALOMINOS
  */
 public abstract class BaseListCA<T> implements ListCA<T>{
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/ColorCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/ColorCA.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.configurationattribute.attribute;
 
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/ColorCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/ColorCA.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -29,6 +32,8 @@ import java.util.Map;
  * This CA represent a color field (like text color or background color) and extends the abstract class BaseCA.
  * On saving, only string type can be used, so the color is saved in a String containing 4 int : red, green, blue, alpha.
  * @see org.orbisgis.mapcomposer.model.configurationattribute.attribute.BaseCA
+ *
+ * @author Sylvain PALOMINOS
  */
 public class ColorCA extends BaseCA<Color> {
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/FileListCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/FileListCA.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.configurationattribute.attribute;
 
 import org.orbisgis.mapcomposer.controller.UIController;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/FileListCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/FileListCA.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -36,6 +39,8 @@ import java.util.Map;
  * This class represent a list of different files and extends the BaseListCA abstract class.
  * As a file can change (file moved, renamed, deleted ...) if also implements the RefreshCA interface to verify if the files contained still exist.
  * @see org.orbisgis.mapcomposer.model.configurationattribute.attribute.BaseListCA
+ *
+ * @author Sylvain PALOMINOS
  */
 public class FileListCA extends BaseListCA<File> implements RefreshCA{
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/IntegerCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/IntegerCA.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -29,6 +32,8 @@ import java.util.Map;
  * This class represent an integer which can have limits to ensure that its value won't be too high or too low.
  * It extends the BaseCA abstract class.
  * @see org.orbisgis.mapcomposer.model.configurationattribute.attribute.BaseCA
+ *
+ * @author Sylvain PALOMINOS
  */
 public class IntegerCA extends BaseCA<Integer> {
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/IntegerCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/IntegerCA.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.configurationattribute.attribute;
 
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/MapImageListCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/MapImageListCA.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.configurationattribute.attribute;
 
 import org.orbisgis.mapcomposer.controller.UIController;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/MapImageListCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/MapImageListCA.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -37,6 +40,8 @@ import java.util.Map;
  * As the list of MapImage can change, it implements the RefreshCA interface to permit to verify the list.
  * @see org.orbisgis.mapcomposer.model.graphicalelement.element.cartographic.MapImage
  * @see org.orbisgis.mapcomposer.model.configurationattribute.attribute.BaseListCA
+ *
+ * @author Sylvain PALOMINOS
  */
 public class MapImageListCA extends BaseListCA<MapImage> implements RefreshCA{
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/OwsContextCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/OwsContextCA.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.configurationattribute.attribute;
 
 import org.mozilla.javascript.edu.emory.mathcs.backport.java.util.Arrays;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/OwsContextCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/OwsContextCA.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -44,6 +47,8 @@ import org.slf4j.LoggerFactory;
  * The OwsMapContexts are saved in the workspace. The class use the OrbisGIS functions (thanks to the LinkToOrbisGIS class) to get and load them.
  * It contains all the information of the map and permit to get the map rendering, the scale value ...
  * @see org.orbisgis.mapcomposer.model.configurationattribute.attribute.BaseListCA
+ *
+ * @author Sylvain PALOMINOS
  */
 public class OwsContextCA extends BaseListCA<String> implements RefreshCA{
     /** Index of the value selected.*/

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/SourceCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/SourceCA.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.configurationattribute.attribute;
 
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/SourceCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/SourceCA.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -29,6 +32,8 @@ import java.util.Map;
  * The Source attribute contain the path to a specified data source like data, image ...
  * It extends the BaseCA abstract class.
  * @see org.orbisgis.mapcomposer.model.configurationattribute.attribute.BaseCA
+ *
+ * @author Sylvain PALOMINOS
  */
 public class SourceCA extends BaseCA<String>{
     /** Property itself */

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/SourceListCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/SourceListCA.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -34,6 +37,8 @@ import java.util.Map;
  * This class represent a list of source and extends the BaseListCA abstract class.
  * A source can be a list of path to files or a list of values (like up, down, left, right).
  * @see org.orbisgis.mapcomposer.model.configurationattribute.attribute.BaseListCA
+ *
+ * @author Sylvain PALOMINOS
  */
 public class SourceListCA extends BaseListCA<String> implements RefreshCA{
     /** Index of the value selected.*/

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/SourceListCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/SourceListCA.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.configurationattribute.attribute;
 
 import org.mozilla.javascript.edu.emory.mathcs.backport.java.util.Arrays;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/StringCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/StringCA.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.configurationattribute.attribute;
 
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/StringCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/StringCA.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -28,6 +31,8 @@ import java.util.Map;
 /**
  * This class represent a text or a string and extends the BaseCA abstract class.
  * @see org.orbisgis.mapcomposer.model.configurationattribute.attribute.BaseCA
+ *
+ * @author Sylvain PALOMINOS
  */
 public class StringCA extends BaseCA<String>{
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/interfaces/ConfigurationAttribute.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/interfaces/ConfigurationAttribute.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.configurationattribute.interfaces;
 
 import java.util.Map;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/interfaces/ConfigurationAttribute.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/interfaces/ConfigurationAttribute.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -32,6 +35,8 @@ import java.util.Map;
  *  - A boolean telling if the ConfigurationAttribute is in read-only mode or not
  *
  * @param <T> The Class of the property represented. For example, for a text attribute the class should be String.
+ *
+ * @author Sylvain PALOMINOS
  */
 public interface ConfigurationAttribute<T> {
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/interfaces/ListCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/interfaces/ListCA.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.configurationattribute.interfaces;
 
 import java.util.List;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/interfaces/ListCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/interfaces/ListCA.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -32,6 +35,8 @@ import java.util.List;
  *  - An index to know which value from the list is selected
  * @param <T> Type of the values contained in the list.
  * @see org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute
+ *
+ * @author Sylvain PALOMINOS
  */
 public interface ListCA<T> extends ConfigurationAttribute<List<T>> {
     /**

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/interfaces/RefreshCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/interfaces/RefreshCA.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.configurationattribute.interfaces;
 
 import org.orbisgis.mapcomposer.controller.UIController;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/interfaces/RefreshCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/interfaces/RefreshCA.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -26,6 +29,8 @@ import org.orbisgis.mapcomposer.controller.UIController;
 /**
  * This interface for the ConfigurationAttribute allows to define a refresh method.
  * It will be called to refresh the value contained by the GraphicalElement and to verify if it still right.
+ *
+ * @author Sylvain PALOMINOS
  */
 public interface RefreshCA {
     /**

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/utils/CAManager.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/utils/CAManager.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.configurationattribute.utils;
 
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/utils/CAManager.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/utils/CAManager.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -53,6 +56,8 @@ import org.orbisgis.mapcomposer.view.configurationattribute.StringRenderer;
  * This class contain all the ConfigurationAttribute used in the MapComposer. It also manages the link between the ConfigurationAttributes and their Renderer.
  * To be used, a ConfigurationAttribute should be register with its renderer into this class to be recognise by the composer.
  * Each GraphicalElement or ConfigurationAttribute which is not register won't be used.
+ *
+ * @author Sylvain PALOMINOS
  */
 public class CAManager {
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -34,6 +37,8 @@ import java.util.List;
 /**
  * This GraphicalElement represents the document itself. it is display as a blank page, always behind all the other GraphicalElement.
  * The user can set its orientation (portrait or landscape), it format (A4, A3 or custom) and its name.
+ *
+ * @author Sylvain PALOMINOS
  */
 public class Document extends SimpleGE implements GERefresh, AlwaysOnBack {
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.graphicalelement.element;
 
 import org.orbisgis.mapcomposer.model.configurationattribute.attribute.SourceListCA;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -31,6 +34,8 @@ import java.util.List;
 /**
  * Simple implementation of the GraphicalElement interface.
  * It contains all the basic ConfigurationAttributes (CA) and the implementation of the interface functions.
+ *
+ * @author Sylvain PALOMINOS
  */
 public abstract class SimpleGE implements GraphicalElement{
     /** x position of the GE.*/

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.graphicalelement.element;
 
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GraphicalElement;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/MapImage.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/MapImage.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.graphicalelement.element.cartographic;
 
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GERefresh;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/MapImage.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/MapImage.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -32,6 +35,8 @@ import java.awt.image.BufferedImage;
 
 /**
  * This class represent the graphical representation (the image) of the map.
+ *
+ * @author Sylvain PALOMINOS
  */
 public class MapImage extends SimpleCartoGE implements GERefresh {
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.graphicalelement.element.cartographic;
 
 import java.util.ArrayList;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -30,6 +33,8 @@ import org.orbisgis.mapcomposer.model.configurationattribute.attribute.SourceCA;
 /**
  * This class represent the arrow giving the orientation of the map.
  * The user can specify the picture to use as icon.
+ *
+ * @author Sylvain PALOMINOS
  */
 public class Orientation extends SimpleCartoGE{
     

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.graphicalelement.element.cartographic;
 
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -28,6 +31,8 @@ import java.util.List;
 
 /**
  * This class represent the scale of a map. It extends the SimpleCartoGE interface.
+ *
+ * @author Sylvain PALOMINOS
  */
 public class Scale extends SimpleCartoGE{
     

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.graphicalelement.element.cartographic;
 
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.CartographicElement;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -32,6 +35,8 @@ import java.util.List;
 
 /**
  * Simple implementation of the CartographicElement interface.
+ *
+ * @author Sylvain PALOMINOS
  */
 public abstract class SimpleCartoGE extends SimpleGE implements CartographicElement{
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/Image.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/Image.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.graphicalelement.element.illustration;
 
 /**

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/Image.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/Image.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -23,6 +26,8 @@ package org.orbisgis.mapcomposer.model.graphicalelement.element.illustration;
 
 /**
  * Graphical element representing a picture, an image ...
+ *
+ * @author Sylvain PALOMINOS
  */
 public class Image extends SimpleIllustrationGE {
 }

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.graphicalelement.element.illustration;
 
 import org.orbisgis.mapcomposer.model.configurationattribute.attribute.SourceCA;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -31,6 +34,8 @@ import java.util.List;
 
 /**
  * This class is a simple implementation of the IllustrationElement interface and extends the SimpleGE class.
+ *
+ * @author Sylvain PALOMINOS
  */
 public abstract class SimpleIllustrationGE extends SimpleGE implements IllustrationElement{
     

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.graphicalelement.element.text;
 
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -36,6 +39,8 @@ import java.awt.GraphicsEnvironment;
 
 /**
  * GraphicalElement displaying a text. Several aspects can be defined such as the text color, the font,the font size ...
+ *
+ * @author Sylvain PALOMINOS
  */
 public class TextElement extends SimpleGE{
     /** Fonts allowed */

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/interfaces/AlwaysOnBack.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/interfaces/AlwaysOnBack.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -23,6 +26,8 @@ package org.orbisgis.mapcomposer.model.graphicalelement.interfaces;
 
 /**
  * A GraphicalElement implementing this interface will always be under the other GraphicalElement.
+ *
+ * @author Sylvain PALOMINOS
  */
 public interface AlwaysOnBack {
     

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/interfaces/AlwaysOnBack.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/interfaces/AlwaysOnBack.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.graphicalelement.interfaces;
 
 /**

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/interfaces/AlwaysOnFront.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/interfaces/AlwaysOnFront.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -23,6 +26,8 @@ package org.orbisgis.mapcomposer.model.graphicalelement.interfaces;
 
 /**
  * A GraphicalElement implementing this interface will always be over the other GraphicalElements.
+ *
+ * @author Sylvain PALOMINOS
  */
 public interface AlwaysOnFront {
     

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/interfaces/AlwaysOnFront.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/interfaces/AlwaysOnFront.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.graphicalelement.interfaces;
 
 /**

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/interfaces/CartographicElement.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/interfaces/CartographicElement.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -27,6 +30,8 @@ import org.orbisgis.coremap.layerModel.OwsMapContext;
  * This interface extends the GraphicalElement interface and represent a cartographic element based on a OwsMapContext file.
  * It contain the basics filed of a GraphicalElement plus an OwsMapContext (OwsContextCA) which contain all the data from the map created in OrbisGIS.
  * To simply the use of this interface, the OwsMapContext is set by giving its path.
+ *
+ * @author Sylvain PALOMINOS
  */
 public interface CartographicElement extends GraphicalElement{
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/interfaces/CartographicElement.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/interfaces/CartographicElement.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.graphicalelement.interfaces;
 
 import org.orbisgis.coremap.layerModel.OwsMapContext;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/interfaces/GERefresh.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/interfaces/GERefresh.java
@@ -1,8 +1,23 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
 
 package org.orbisgis.mapcomposer.model.graphicalelement.interfaces;
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/interfaces/GERefresh.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/interfaces/GERefresh.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -23,6 +26,8 @@ package org.orbisgis.mapcomposer.model.graphicalelement.interfaces;
 
 /**
  * Interface that will permite to implement the refresh of data contained by the GraphicalElement.
+ *
+ * @author Sylvain PALOMINOS
  */
 public interface GERefresh {
     public void refresh();

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/interfaces/GraphicalElement.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/interfaces/GraphicalElement.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -38,6 +41,8 @@ import java.util.List;
  *  - The z index (int). This index indicate if an object is over or under an other one.
  *
  *  All of those fields are associated to setters and getters.
+ *
+ * @author Sylvain PALOMINOS
  */
 public interface GraphicalElement {
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/interfaces/GraphicalElement.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/interfaces/GraphicalElement.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.graphicalelement.interfaces;
 
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/interfaces/IllustrationElement.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/interfaces/IllustrationElement.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -24,6 +27,8 @@ package org.orbisgis.mapcomposer.model.graphicalelement.interfaces;
 /**
  * This interface extends the GraphicalElement interface and represent an illustration like an image, data ...
  * It contain the basic filed of a GraphicalElement plus a path to the source (SourceCA) used to generate the illustration.
+ *
+ * @author Sylvain PALOMINOS
  */
 public interface IllustrationElement extends GraphicalElement{
     /**

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/interfaces/IllustrationElement.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/interfaces/IllustrationElement.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.graphicalelement.interfaces;
 
 /**

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/utils/GEManager.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/utils/GEManager.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -37,6 +40,8 @@ import java.util.*;
  * This class contain all the GraphicalElement used in the MapComposer. It also manages the link between the GraphicalElements (GE) and their Renderer.
  * To be used, a GraphicalElement should be register with its renderer into this class to be recognise by the composer.
  * Each GraphicalElement or GraphicalElementRenderer which is not register won't be used.
+ *
+ * @author Sylvain PALOMINOS
  */
 public class GEManager {
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/utils/GEManager.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/utils/GEManager.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.graphicalelement.utils;
 
 import org.orbisgis.mapcomposer.model.graphicalelement.element.Document;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/utils/LinkToOrbisGIS.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/utils/LinkToOrbisGIS.java
@@ -1,8 +1,23 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
 
 package org.orbisgis.mapcomposer.model.utils;
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/utils/LinkToOrbisGIS.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/utils/LinkToOrbisGIS.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -33,6 +36,8 @@ import org.osgi.framework.ServiceReference;
 /**
  * Class giving a link to OrbisGIS.
  * It give an access to usefull classes instance of OrbisGIS.
+ *
+ * @author Sylvain PALOMINOS
  */
 public class LinkToOrbisGIS {
     /** Unique instance of the class*/

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.model.utils;
 
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -54,6 +57,8 @@ import javax.xml.parsers.SAXParserFactory;
  * This class permits to manage the save and the load of a document project and it uses the sax api to do a save into an xml file.
  * All the saves contain the version of the MapComposer used to do it. The class contain an array of those version to know with which version it is compatible.
  * In the documentation the "reader" correspond to the position where the files is actually read.
+ *
+ * @author Sylvain PALOMINOS
  */
 public class SaveAndLoadHandler extends DefaultHandler {
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/CARenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/CARenderer.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -30,6 +33,8 @@ import javax.swing.*;
  * The createJComponentFromCA function return a JComponent containing all swing components (JLabel, JButton, JSpinner ...) necessary to the user to configure the attribute.
  * Thanks to this method, all the ConfigurationAttributes of a GraphicalElement are display into the configuration window.
  * The link between a CA and its Renderer will be done by the CAManager.
+ *
+ * @author Sylvain PALOMINOS
  */
 public interface CARenderer {
     /**

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/CARenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/CARenderer.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.view.configurationattribute;
 
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/ColorRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/ColorRenderer.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.view.configurationattribute;
 
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/ColorRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/ColorRenderer.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -41,6 +44,8 @@ import javax.swing.*;
  *
  * The color is chosen by clicking on a button. It opens a ColorChooser and the color is saved in the background of the button
  * @see org.orbisgis.mapcomposer.model.configurationattribute.attribute.ColorCA
+ *
+ * @author Sylvain PALOMINOS
  */
 public class ColorRenderer implements CARenderer{
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/FileListRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/FileListRenderer.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -39,6 +42,8 @@ import javax.swing.*;
  * |________________________________________________________________|
  *
  * @see org.orbisgis.mapcomposer.model.configurationattribute.attribute.FileListCA
+ *
+ * @author Sylvain PALOMINOS
  */
 public class FileListRenderer implements CARenderer{
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/FileListRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/FileListRenderer.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.view.configurationattribute;
 
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/IntegerRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/IntegerRenderer.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -40,6 +43,8 @@ import javax.swing.event.ChangeListener;
  * |________________________________________________________________|
  *
  * @see org.orbisgis.mapcomposer.model.configurationattribute.attribute.IntegerCA
+ *
+ * @author Sylvain PALOMINOS
  */
 public class IntegerRenderer implements CARenderer{
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/IntegerRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/IntegerRenderer.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.view.configurationattribute;
 
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/MapImageListRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/MapImageListRenderer.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -41,6 +44,8 @@ import javax.swing.*;
  * |_________________________________________________________________|
  *
  * @see org.orbisgis.mapcomposer.model.configurationattribute.attribute.MapImageListCA
+ *
+ * @author Sylvain PALOMINOS
  */
 public class MapImageListRenderer implements CARenderer{
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/MapImageListRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/MapImageListRenderer.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.view.configurationattribute;
 
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/OwsContextRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/OwsContextRenderer.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -38,6 +41,8 @@ import javax.swing.*;
  * |_________________________________________________________________|
  *
  * @see org.orbisgis.mapcomposer.model.configurationattribute.attribute.OwsContextCA
+ *
+ * @author Sylvain PALOMINOS
  */
 public class OwsContextRenderer implements CARenderer{
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/OwsContextRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/OwsContextRenderer.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.view.configurationattribute;
 
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/SourceListRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/SourceListRenderer.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -38,6 +41,8 @@ import javax.swing.*;
  * |________________________________________________________________|
  *
  * @see org.orbisgis.mapcomposer.model.configurationattribute.attribute.SourceListCA
+ *
+ * @author Sylvain PALOMINOS
  */
 public class SourceListRenderer implements CARenderer{
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/SourceListRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/SourceListRenderer.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.view.configurationattribute;
 
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -47,6 +50,8 @@ import java.beans.EventHandler;
  *
  * A button open a JFileChooser to permit to the user to find the source file.
  * @see org.orbisgis.mapcomposer.model.configurationattribute.attribute.SourceCA
+ *
+ * @author Sylvain PALOMINOS
  */
 public class SourceRenderer implements CARenderer{
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.view.configurationattribute;
 
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java
@@ -40,17 +40,22 @@ public class SourceRenderer implements CARenderer{
         
         component.add(new JLabel(sourceCA.getName()));
         //Display the SourceCA into a JTextField
-        JTextField jtf = new JTextField(sourceCA.getValue());
+        JTextField jtf = new JTextField();
         jtf.setColumns(40);
         //"Save" the CA inside the JTextField
         jtf.getDocument().putProperty("SourceCA", sourceCA);
         //add the listener for the text changes in the JTextField
         jtf.getDocument().addDocumentListener(EventHandler.create(DocumentListener.class, this, "saveDocumentText", "document"));
-        //Load the last path use in a sourceCA
-        OpenFilePanel openFilePanel = new OpenFilePanel("ConfigurationAttribute.SourceCA", "Select source");
-        openFilePanel.addFilter(new String[]{"*"}, "All files");
-        openFilePanel.loadState();
-        jtf.setText(openFilePanel.getCurrentDirectory().getAbsolutePath());
+
+        if(sourceCA.getValue()!="")
+            jtf.setText(sourceCA.getValue());
+        else {
+            //Load the last path use in a sourceCA
+            OpenFilePanel openFilePanel = new OpenFilePanel("ConfigurationAttribute.SourceCA", "Select source");
+            openFilePanel.addFilter(new String[]{"*"}, "All files");
+            openFilePanel.loadState();
+            jtf.setText(openFilePanel.getCurrentDirectory().getAbsolutePath());
+        }
 
         component.add(jtf);
         //Create the button Browse

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/StringRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/StringRenderer.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -40,6 +43,8 @@ import javax.swing.text.Document;
  * |_________________________________________________________________|
  *
  * @see org.orbisgis.mapcomposer.model.configurationattribute.attribute.StringCA
+ *
+ * @author Sylvain PALOMINOS
  */
 public class StringRenderer implements CARenderer{
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/StringRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/StringRenderer.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.view.configurationattribute;
 
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.view.graphicalelement;
 
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GraphicalElement;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -28,6 +31,8 @@ import java.awt.image.BufferedImage;
 
 /**
  * Renderer associated to the Document GraphicalElement.
+ *
+ * @author Sylvain PALOMINOS
  */
 public class DocumentRenderer extends SimpleGERenderer {
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/GERenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/GERenderer.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -28,6 +31,8 @@ import javax.swing.JPanel;
 /**
  * Base interface for the implementation of a render class associated to a GraphicalElement.
  * It contain a function returning the graphical representation of a GraphicalElement.
+ *
+ * @author Sylvain PALOMINOS
  */
 public interface  GERenderer {
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/GERenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/GERenderer.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.view.graphicalelement;
 
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GraphicalElement;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/ImageRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/ImageRenderer.java
@@ -31,7 +31,7 @@ public class ImageRenderer extends SimpleGERenderer {
         g.dispose();
 
         //Scale the bufferedImage to the GraphicalElement size
-        java.awt.Image image = bi.getScaledInstance(ge.getWidth(), ge.getHeight(), java.awt.Image.SCALE_FAST);
+        java.awt.Image image = bi.getScaledInstance(ge.getWidth(), ge.getHeight(), java.awt.Image.SCALE_SMOOTH);
         BufferedImage resize = new BufferedImage(ge.getWidth(), ge.getHeight(), BufferedImage.TYPE_INT_ARGB);
         Graphics graph = resize.createGraphics();
         graph.drawImage(image, 0, 0, null);

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/ImageRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/ImageRenderer.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -32,6 +35,8 @@ import javax.swing.ImageIcon;
 
 /**
  * Renderer associated to the Image GraphicalElement.
+ *
+ * @author Sylvain PALOMINOS
  */
 public class ImageRenderer extends SimpleGERenderer {
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/ImageRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/ImageRenderer.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.view.graphicalelement;
 
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GraphicalElement;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/MapImageRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/MapImageRenderer.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -31,6 +34,8 @@ import java.awt.image.BufferedImage;
 
 /**
  * Renderer associated to the Cartographic GraphicalElement.
+ *
+ * @author Sylvain PALOMINOS
  */
 public class MapImageRenderer extends SimpleGERenderer {
     

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/MapImageRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/MapImageRenderer.java
@@ -30,7 +30,7 @@ public class MapImageRenderer extends SimpleGERenderer {
         }
 
         //Scale the bufferedImage to the GraphicalElement size
-        java.awt.Image image = bi.getScaledInstance(ge.getWidth(), ge.getHeight(), java.awt.Image.SCALE_FAST);
+        java.awt.Image image = bi.getScaledInstance(ge.getWidth(), ge.getHeight(), Image.SCALE_SMOOTH);
         BufferedImage resize = new BufferedImage(ge.getWidth(), ge.getHeight(), BufferedImage.TYPE_INT_ARGB);
         Graphics graph = resize.createGraphics();
         graph.drawImage(image, 0, 0, null);

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/MapImageRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/MapImageRenderer.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.view.graphicalelement;
 
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GraphicalElement;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/OrientationRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/OrientationRenderer.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -32,6 +35,8 @@ import javax.swing.ImageIcon;
 
 /**
  * Renderer associated to the Orientation GraphicalElement.
+ *
+ * @author Sylvain PALOMINOS
  */
 public class OrientationRenderer extends SimpleGERenderer {
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/OrientationRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/OrientationRenderer.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.view.graphicalelement;
 
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GraphicalElement;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/OrientationRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/OrientationRenderer.java
@@ -31,7 +31,7 @@ public class OrientationRenderer extends SimpleGERenderer {
         g.dispose();
 
         //Scale the bufferedImage to the GraphicalElement size
-        java.awt.Image image = bi.getScaledInstance(ge.getWidth(), ge.getHeight(), java.awt.Image.SCALE_FAST);
+        java.awt.Image image = bi.getScaledInstance(ge.getWidth(), ge.getHeight(), java.awt.Image.SCALE_SMOOTH);
         BufferedImage resize = new BufferedImage(ge.getWidth(), ge.getHeight(), BufferedImage.TYPE_INT_ARGB);
         Graphics graph = resize.createGraphics();
         graph.drawImage(image, 0, 0, null);

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/ScaleRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/ScaleRenderer.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.view.graphicalelement;
 
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GraphicalElement;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/ScaleRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/ScaleRenderer.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -29,6 +32,8 @@ import java.awt.image.BufferedImage;
 
 /**
  * Renderer associated to the scale GraphicalElement.
+ *
+ * @author Sylvain PALOMINOS
  */
 public class ScaleRenderer extends SimpleGERenderer {
     /**Dot per millimeter screen resolution. */

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/SimpleGERenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/SimpleGERenderer.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -35,6 +38,8 @@ import static java.lang.Math.sin;
  * This abstract class contain a function applying to the bufferedImage the rotation angle of the GraphicalElement.
  * In fact, after the rotation, the bounding box of the image will be bigger. So if the original bounding box is kept, the image will be cut.
  * That's why a new image is created, with the new Bounding box and the original image is drawn inside. After the rotation the image won't be cut.
+ *
+ * @author Sylvain PALOMINOS
  */
 public abstract class SimpleGERenderer implements GERenderer {
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/SimpleGERenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/SimpleGERenderer.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.view.graphicalelement;
 
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GraphicalElement;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/TextRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/TextRenderer.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -34,6 +37,8 @@ import java.text.AttributedString;
 
 /**
  * Renderer associated to the scale GraphicalElement.
+ *
+ * @author Sylvain PALOMINOS
  */
 public class TextRenderer extends SimpleGERenderer {
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/TextRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/TextRenderer.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.view.graphicalelement;
 
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GraphicalElement;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/CompositionArea.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/CompositionArea.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.view.ui;
 
 import org.orbisgis.mapcomposer.controller.UIController;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/CompositionArea.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/CompositionArea.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -36,6 +39,8 @@ import javax.swing.plaf.LayerUI;
 /**
  * Area for the map document composition.
  * All the GraphicalElement will be drawn inside.
+ *
+ * @author Sylvain PALOMINOS
  */
 public class CompositionArea extends JPanel{
     

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/CompositionArea.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/CompositionArea.java
@@ -6,7 +6,9 @@ import org.orbisgis.mapcomposer.view.utils.CompositionJPanel;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.Graphics;
+import java.awt.event.MouseListener;
 import java.awt.image.BufferedImage;
+import java.beans.EventHandler;
 import javax.swing.*;
 import javax.swing.plaf.LayerUI;
 
@@ -44,6 +46,8 @@ public class CompositionArea extends JPanel{
         layerUI = new CompositionAreaOverlay(uiController);
         jLayer = new JLayer<>(panel, layerUI);
         this.add(jLayer);
+
+        panel.addMouseListener(EventHandler.create(MouseListener.class, uiController, "unselectAllGE", null, "mouseClicked"));
     }
 
     /**

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/MainWindow.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/MainWindow.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.view.ui;
 
 import org.orbisgis.mapcomposer.controller.UIController;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/MainWindow.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/MainWindow.java
@@ -337,55 +337,70 @@ public class MainWindow extends JFrame implements MainFrameAction{
      * Add a MapImage GraphicalElement to the document.
      */
     public void addMap(){
-        compositionArea.getOverlay().setRatio(-1);
-        uiController.createNewGE(MapImage.class);
-        compositionArea.setOverlayMode(CompositionAreaOverlay.Mode.NEW_GE);
-
+        if(uiController.isDocumentCreated()) {
+            compositionArea.getOverlay().setRatio(-1);
+            uiController.createNewGE(MapImage.class);
+            compositionArea.setOverlayMode(CompositionAreaOverlay.Mode.NEW_GE);
+        }
     }
 
     /**
      * Add a TextElement GraphicalElement to the document.
      */
     public void addText(){
-        uiController.createNewGE(TextElement.class);
-        compositionArea.setOverlayMode(CompositionAreaOverlay.Mode.NEW_GE);
+        if(uiController.isDocumentCreated()) {
+            uiController.createNewGE(TextElement.class);
+            compositionArea.setOverlayMode(CompositionAreaOverlay.Mode.NEW_GE);
+        }
     }
 
     /**
      * Add a Legend GraphicalElement to the document.
      */
     public void addLegend(){
-        //Unsupported yet
+        if(uiController.isDocumentCreated()) {
+            //Unsupported yet
+        }
     }
 
     /**
      * Add a Orientation GraphicalElement to the document.
      */
     public void addOrientation(){
-        uiController.createNewGE(Orientation.class);
-        compositionArea.setOverlayMode(CompositionAreaOverlay.Mode.NEW_GE);
+        if(uiController.isDocumentCreated()) {
+            uiController.createNewGE(Orientation.class);
+            compositionArea.setOverlayMode(CompositionAreaOverlay.Mode.NEW_GE);
+        }
     }
 
     /**
      * Add a Scale GraphicalElement to the document.
      */
     public void addScale(){
-        uiController.createNewGE(Scale.class);
-        compositionArea.setOverlayMode(CompositionAreaOverlay.Mode.NEW_GE);
+        if(uiController.isDocumentCreated()) {
+            uiController.createNewGE(Scale.class);
+            compositionArea.setOverlayMode(CompositionAreaOverlay.Mode.NEW_GE);
+        }
     }
 
     /**
      * Add a Image GraphicalElement to the document.
      */
     public void addPicture() {
-        uiController.createNewGE(Image.class);
-        compositionArea.setOverlayMode(CompositionAreaOverlay.Mode.NEW_GE);
+        if(uiController.isDocumentCreated()) {
+            uiController.createNewGE(Image.class);
+            compositionArea.setOverlayMode(CompositionAreaOverlay.Mode.NEW_GE);
+        }
     }
     public void drawCircle(){
-        //Unsupported yet
+        if(uiController.isDocumentCreated()) {
+            //Unsupported yet
+        }
     }
     public void drawPolygon(){
-        //Unsupported yet
+        if(uiController.isDocumentCreated()) {
+            //Unsupported yet
+        }
     }
     public void moveBack(){
         uiController.changeZIndex(ZIndex.TO_BACK);

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/MainWindow.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/MainWindow.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -49,6 +52,8 @@ import org.orbisgis.viewapi.main.frames.ext.MainFrameAction;
 /**
  * Main window of the map composer. It contain the saverals tool bar and the CompositionArea.
  * It does the link between the user interactions and the UIController
+ *
+ * @author Sylvain PALOMINOS
  */
 public class MainWindow extends JFrame implements MainFrameAction{
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/MainWindow.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/MainWindow.java
@@ -11,26 +11,13 @@ import org.orbisgis.mapcomposer.model.graphicalelement.element.illustration.Imag
 import org.orbisgis.mapcomposer.model.graphicalelement.element.text.TextElement;
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GraphicalElement;
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GraphicalElement.Property;
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.awt.event.ActionListener;
-import java.awt.event.MouseWheelEvent;
-import java.awt.event.MouseWheelListener;
+
+import java.awt.*;
+import java.awt.event.*;
 import java.beans.EventHandler;
 import java.util.ArrayList;
 import java.util.List;
-import javax.swing.Action;
-import javax.swing.BoxLayout;
-import javax.swing.ImageIcon;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JSeparator;
-import javax.swing.JSpinner;
-import javax.swing.JToolBar;
-import javax.swing.KeyStroke;
-import javax.swing.SpinnerNumberModel;
-import javax.swing.SwingConstants;
+import javax.swing.*;
 import javax.swing.event.ChangeListener;
 
 import org.orbisgis.mapcomposer.view.utils.CompositionAreaOverlay;
@@ -325,7 +312,6 @@ public class MainWindow extends JFrame implements MainFrameAction{
         uiController.removeAllGE();
         uiController.instantiateGE(Document.class);
         uiController.setNewGE(0, 0, 1, 1);
-        compositionArea.setOverlayMode(CompositionAreaOverlay.Mode.NONE);
     }
 
     /**
@@ -442,9 +428,9 @@ public class MainWindow extends JFrame implements MainFrameAction{
     @Override
     public List<Action> createActions(org.orbisgis.viewapi.main.frames.ext.MainWindow target) {
         List<Action> actions = new ArrayList<>();
-        actions.add(new DefaultAction(MENU_MAPCOMPOSER,"Map Composer",
+        actions.add(new DefaultAction(MENU_MAPCOMPOSER, "Map Composer",
                 new ImageIcon(MainWindow.class.getResource("map_composer.png")),
-                EventHandler.create(ActionListener.class,this,"showMapComposer")).setParent(MENU_TOOLS));
+                EventHandler.create(ActionListener.class, this, "showMapComposer")).setParent(MENU_TOOLS));
         return actions;
     }
     public void showMapComposer(){this.setVisible(true);}

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/MainWindow.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/MainWindow.java
@@ -312,16 +312,8 @@ public class MainWindow extends JFrame implements MainFrameAction{
                 break;
         }
         if(spinner!=null){
-            if(value == spinner.getValue()){
-                spinner.setModel(new SpinnerNumberModel(value, ((SpinnerNumberModel) spinner.getModel()).getMinimum(), ((SpinnerNumberModel) spinner.getModel()).getMaximum(), 1));
-                spinner.setEnabled(!b);
-                spinner.addChangeListener(EventHandler.create(ChangeListener.class, this, "spinChange", "source"));
-                spinner.addMouseWheelListener(EventHandler.create(MouseWheelListener.class, this, "mouseWheel", ""));
-            }
-            else {
-                spinner.setValue(val);
-                spinner.setEnabled(!b);
-            }
+            spinner.setModel(new SpinnerNumberModel(value, ((SpinnerNumberModel) spinner.getModel()).getMinimum(), ((SpinnerNumberModel) spinner.getModel()).getMaximum(), 1));
+            spinner.setEnabled(!b);
         }
     }
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/MainWindow.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/MainWindow.java
@@ -293,27 +293,35 @@ public class MainWindow extends JFrame implements MainFrameAction{
      */
     public void setSpinner(boolean b, int value, Property prop){
         int val=b ? 0 : value;
+        JSpinner spinner = null;
         switch(prop){
             case X:
-                spinnerX.setEnabled(!b);
-                spinnerX.setValue(val);
+                spinner = spinnerX;
                 break;
             case Y:
-                spinnerY.setEnabled(!b);
-                spinnerY.setValue(val);
+                spinner = spinnerY;
                 break;
             case HEIGHT:
-                spinnerH.setEnabled(!b);
-                spinnerH.setValue(val);
+                spinner = spinnerH;
                 break;
             case WIDTH:
-                spinnerW.setEnabled(!b);
-                spinnerW.setValue(val);
+                spinner = spinnerW;
                 break;
             case ROTATION:
-                spinnerR.setEnabled(!b);
-                spinnerR.setValue(val);
+                spinner = spinnerR;
                 break;
+        }
+        if(spinner!=null){
+            if(value == spinner.getValue()){
+                spinner.setModel(new SpinnerNumberModel(value, ((SpinnerNumberModel) spinner.getModel()).getMinimum(), ((SpinnerNumberModel) spinner.getModel()).getMaximum(), 1));
+                spinner.setEnabled(!b);
+                spinner.addChangeListener(EventHandler.create(ChangeListener.class, this, "spinChange", "source"));
+                spinner.addMouseWheelListener(EventHandler.create(MouseWheelListener.class, this, "mouseWheel", ""));
+            }
+            else {
+                spinner.setValue(val);
+                spinner.setEnabled(!b);
+            }
         }
     }
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/MainWindow.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/MainWindow.java
@@ -102,6 +102,7 @@ public class MainWindow extends JFrame implements MainFrameAction{
         this.compositionArea = new CompositionArea(uiController);
         //Sets the default size to the window
         this.setSize(1024, 768);
+        this.setIconImage(new ImageIcon(MainWindow.class.getResource("map_composer.png")).getImage());
 
         //Creates the panel containing the two tool bars.
         JPanel toolBarPanel = new JPanel();
@@ -119,7 +120,7 @@ public class MainWindow extends JFrame implements MainFrameAction{
         actions.addAction(createAction(NEW_COMPOSER, "", "Create a new document", "new_composer.png", this, "newComposer", null));
         actions.addAction(createAction(CONFIGURATION, "", "Show the document configuration dialog", "configuration.png", uiController, "showDocProperties", null));
         actions.addAction(createAction(SAVE, "", "Save the document", "save.png", uiController, "saveDocument", null));
-        actions.addAction(createAction(LOAD, "", "Load the document", "properties.png", uiController, "loadDocument", null));
+        actions.addAction(createAction(LOAD, "", "Load the document", "load.png", uiController, "loadDocument", null));
         actions.addAction(createAction(EXPORT_COMPOSER, "", "Export the document", "export_composer.png", this, "exportComposer", null));
         addSeparatortTo(IconToolBar);
         actions.addAction(createAction(ADD_MAP, "", "Add a map element", "add_map.png", this, "addMap", null));
@@ -442,7 +443,7 @@ public class MainWindow extends JFrame implements MainFrameAction{
     public List<Action> createActions(org.orbisgis.viewapi.main.frames.ext.MainWindow target) {
         List<Action> actions = new ArrayList<>();
         actions.add(new DefaultAction(MENU_MAPCOMPOSER,"Map Composer",
-                new ImageIcon(),
+                new ImageIcon(MainWindow.class.getResource("map_composer.png")),
                 EventHandler.create(ActionListener.class,this,"showMapComposer")).setParent(MENU_TOOLS));
         return actions;
     }

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/MainWindow.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/MainWindow.java
@@ -322,8 +322,9 @@ public class MainWindow extends JFrame implements MainFrameAction{
      */
     public void newComposer(){
         uiController.removeAllGE();
-        uiController.createNewGE(Document.class);
+        uiController.instantiateGE(Document.class);
         uiController.setNewGE(0, 0, 1, 1);
+        compositionArea.setOverlayMode(CompositionAreaOverlay.Mode.NONE);
     }
 
     /**
@@ -339,8 +340,8 @@ public class MainWindow extends JFrame implements MainFrameAction{
     public void addMap(){
         if(uiController.isDocumentCreated()) {
             compositionArea.getOverlay().setRatio(-1);
-            uiController.createNewGE(MapImage.class);
-            compositionArea.setOverlayMode(CompositionAreaOverlay.Mode.NEW_GE);
+            uiController.instantiateGE(MapImage.class);
+            compositionArea.setOverlayMode(CompositionAreaOverlay.Mode.NONE);
         }
     }
 
@@ -349,8 +350,9 @@ public class MainWindow extends JFrame implements MainFrameAction{
      */
     public void addText(){
         if(uiController.isDocumentCreated()) {
-            uiController.createNewGE(TextElement.class);
-            compositionArea.setOverlayMode(CompositionAreaOverlay.Mode.NEW_GE);
+            compositionArea.getOverlay().setRatio(-1);
+            uiController.instantiateGE(TextElement.class);
+            compositionArea.setOverlayMode(CompositionAreaOverlay.Mode.NONE);
         }
     }
 
@@ -368,8 +370,9 @@ public class MainWindow extends JFrame implements MainFrameAction{
      */
     public void addOrientation(){
         if(uiController.isDocumentCreated()) {
-            uiController.createNewGE(Orientation.class);
-            compositionArea.setOverlayMode(CompositionAreaOverlay.Mode.NEW_GE);
+            compositionArea.getOverlay().setRatio(-1);
+            uiController.instantiateGE(Orientation.class);
+            compositionArea.setOverlayMode(CompositionAreaOverlay.Mode.NONE);
         }
     }
 
@@ -378,8 +381,9 @@ public class MainWindow extends JFrame implements MainFrameAction{
      */
     public void addScale(){
         if(uiController.isDocumentCreated()) {
-            uiController.createNewGE(Scale.class);
-            compositionArea.setOverlayMode(CompositionAreaOverlay.Mode.NEW_GE);
+            compositionArea.getOverlay().setRatio(-1);
+            uiController.instantiateGE(Scale.class);
+            compositionArea.setOverlayMode(CompositionAreaOverlay.Mode.NONE);
         }
     }
 
@@ -388,8 +392,9 @@ public class MainWindow extends JFrame implements MainFrameAction{
      */
     public void addPicture() {
         if(uiController.isDocumentCreated()) {
-            uiController.createNewGE(Image.class);
-            compositionArea.setOverlayMode(CompositionAreaOverlay.Mode.NEW_GE);
+            compositionArea.getOverlay().setRatio(-1);
+            uiController.instantiateGE(Image.class);
+            compositionArea.setOverlayMode(CompositionAreaOverlay.Mode.NONE);
         }
     }
     public void drawCircle(){
@@ -435,7 +440,7 @@ public class MainWindow extends JFrame implements MainFrameAction{
 
     @Override
     public List<Action> createActions(org.orbisgis.viewapi.main.frames.ext.MainWindow target) {
-        List<Action> actions = new ArrayList<Action>();
+        List<Action> actions = new ArrayList<>();
         actions.add(new DefaultAction(MENU_MAPCOMPOSER,"Map Composer",
                 new ImageIcon(),
                 EventHandler.create(ActionListener.class,this,"showMapComposer")).setParent(MENU_TOOLS));

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/ColorChooser.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/ColorChooser.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.view.utils;
 
 import java.awt.Color;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/ColorChooser.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/ColorChooser.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -28,6 +31,8 @@ import javax.swing.*;
 
 /**
  * Color chooser
+ *
+ * @author Sylvain PALOMINOS
  */
 public class ColorChooser extends JFrame{
     private final JComponent label;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/CompositionAreaOverlay.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/CompositionAreaOverlay.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -32,6 +35,8 @@ import java.awt.event.MouseEvent;
  * This class is used as an overlay to the CompositionArea to permit to draw the bounding box of a new GraphicalElement.
  * It will be enabled only when the user wants to create a new GraphicalElement. So the user can draw the bounding box of the new GraphicalElement.
  * The size will be transfer to the UIController to create the GE.
+ *
+ * @author Sylvain PALOMINOS
  */
 public class CompositionAreaOverlay extends LayerUI<JComponent>{
     /*Point where the mouse is pressed.*/

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/CompositionAreaOverlay.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/CompositionAreaOverlay.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.view.utils;
 
 import org.orbisgis.mapcomposer.controller.UIController;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java
@@ -84,17 +84,13 @@ public class CompositionJPanel extends JPanel{
         this.add(layer);
     }
 
-    /**
-     * Sets the panel contained by the object.
-     * @param bufferedImage The new panel.
-     */
-    public void setPanelContent(final BufferedImage bufferedImage){
-        double rad = Math.toRadians(ge.getRotation());
+    public void redraw(int x, int y, int width, int height, int rotation, final BufferedImage bufferedImage){
+        double rad = Math.toRadians(rotation);
         //Width and Height of the rectangle containing the rotated bufferedImage
-        final double newWidth = Math.abs(cos(rad)*ge.getWidth())+Math.abs(sin(rad)*ge.getHeight());
-        final double newHeight = Math.abs(cos(rad)*ge.getHeight())+Math.abs(sin(rad)*ge.getWidth());
-        final int maxWidth = Math.max((int)newWidth, ge.getWidth());
-        final int maxHeight = Math.max((int)newHeight, ge.getHeight());
+        final double newWidth = Math.abs(cos(rad)*width)+Math.abs(sin(rad)*height);
+        final double newHeight = Math.abs(cos(rad)*height)+Math.abs(sin(rad)*width);
+        final int maxWidth = Math.max((int)newWidth, width);
+        final int maxHeight = Math.max((int)newHeight, height);
 
         panel.removeAll();
         //Add the BufferedImage into a JComponent in the CompositionJPanel
@@ -107,10 +103,18 @@ public class CompositionJPanel extends JPanel{
             }
         }, BorderLayout.CENTER);
         panel.revalidate();
+        modify(x, y, width, height, rotation);
+    }
+
+    public void modify(int x, int y, int width, int height, int rotation){
+        double rad = Math.toRadians(rotation);
+        //Width and Height of the rectangle containing the rotated bufferedImage
+        final double newWidth = Math.abs(cos(rad)*width)+Math.abs(sin(rad)*height);
+        final double newHeight = Math.abs(cos(rad)*height)+Math.abs(sin(rad)*width);
         this.revalidate();
         //As the buffered image is rotated, change the origin point of the panel to make the center of the image not moving after the rotation.
         //Take account of the border width (2 pixels).
-        this.setBounds(ge.getX() + (ge.getWidth() - (int) newWidth) / 2, ge.getY() + (ge.getHeight() - (int) newHeight) / 2, (int) newWidth + 2, (int) newHeight + 2);
+        this.setBounds(x + (width - (int) newWidth) / 2, y + (height - (int) newHeight) / 2, (int) newWidth + 2, (int) newHeight + 2);
         this.setOpaque(false);
         panel.setOpaque(false);
         setBorders();
@@ -630,7 +634,7 @@ public class CompositionJPanel extends JPanel{
     }
 
     /**
-     * Changes the mouse cursor appearence according to the border hovered.
+     * Changes the mouse cursor appearance according to the border hovered.
      * @param p Point of the mouse.
      */
     public void mouseMoved(Point p) {

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -42,6 +45,8 @@ import javax.swing.*;
 
  /**
   * This panel extends from JPanel define the action to do when the user click on it.
+  *
+  * @author Sylvain PALOMINOS
   */
 public class CompositionJPanel extends JPanel{
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java
@@ -141,6 +141,10 @@ public class CompositionJPanel extends JPanel{
             uic.unselectGE(ge);
         else
             uic.selectGE(ge);
+
+        this.moveDirection = MoveDirection.NONE;
+        this.moveMode=MoveMode.NONE;
+        uic.getMainWindow().getCompositionArea().getOverlay().setMode(CompositionAreaOverlay.Mode.NONE);
     }
 
     /**
@@ -211,6 +215,10 @@ public class CompositionJPanel extends JPanel{
     * @param p Location on screen of the mouse when it's released.
     */
     public void mouseReleasedHub(Point p){
+        //If the mouse didn't moved, it means the user had clicked, so skips the mouse released actions.
+        if(p.x==startX && p.y==startY)
+            return;
+
         if(moveDirection==MoveDirection.CENTER) {
             ge.setX(ge.getX() - startX + p.x);
             ge.setY(ge.getY() - startY + p.y);
@@ -243,8 +251,7 @@ public class CompositionJPanel extends JPanel{
             this.moveDirection = MoveDirection.NONE;
             this.moveMode=MoveMode.NONE;
         }
-
-    uic.getMainWindow().getCompositionArea().getOverlay().setMode(CompositionAreaOverlay.Mode.NONE);
+        uic.getMainWindow().getCompositionArea().getOverlay().setMode(CompositionAreaOverlay.Mode.NONE);
     }
 
      /**

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java
@@ -127,6 +127,14 @@ public class CompositionJPanel extends JPanel{
         contentImage = affineTransformOp.filter(contentImage, null);
     }
 
+     /**
+      * Modify the bounding box of the panel without redrawing the content image.
+      * @param x X position of the GE represented.
+      * @param y Y position of the GE represented.
+      * @param width Width of the GE represented.
+      * @param height Height of the GE represented.
+      * @param rotation Rotation of the GE represented.
+      */
     public void modify(int x, int y, int width, int height, int rotation){
         final double rad = Math.toRadians(rotation);
         //Width and Height of the rectangle containing the rotated bufferedImage

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java
@@ -59,8 +59,6 @@ public class CompositionJPanel extends JPanel{
 
     private BufferedImage contentImage;
 
-    private static int i = 0;
-
     /**
      * Main constructor.
      * @param ge GraphicalElement to display.
@@ -130,7 +128,6 @@ public class CompositionJPanel extends JPanel{
     }
 
     public void modify(int x, int y, int width, int height, int rotation){
-        System.out.println(i);
         final double rad = Math.toRadians(rotation);
         //Width and Height of the rectangle containing the rotated bufferedImage
         final double newWidth = Math.abs(cos(rad)*width)+Math.abs(sin(rad)*height);
@@ -175,7 +172,6 @@ public class CompositionJPanel extends JPanel{
         this.setOpaque(false);
         panel.setOpaque(false);
         setBorders();
-        i++;
     }
 
     /**

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java
@@ -1,4 +1,25 @@
- package org.orbisgis.mapcomposer.view.utils;
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
+package org.orbisgis.mapcomposer.view.utils;
 
 import org.orbisgis.coremap.renderer.se.graphic.Graphic;
 import org.orbisgis.mapcomposer.controller.UIController;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java
@@ -50,7 +50,10 @@ public class CompositionJPanel extends JPanel{
     
     /** Size of the margin of the border for resizing. */
     private static final int margin = 5;
-    
+
+    private WaitLayerUI waitLayer;
+    private JPanel panel;
+
     /**
      * Main constructor.
      * @param ge GraphicalElement to display.
@@ -58,6 +61,9 @@ public class CompositionJPanel extends JPanel{
      */
     public CompositionJPanel(GraphicalElement ge, UIController uic){
         super(new BorderLayout());
+        this.setSize(ge.getWidth(), ge.getHeight());
+        panel = new JPanel(new BorderLayout());
+        this.add(panel);
         this.uic=uic;
         this.ge=ge;
         //Disable mouse listeners if it's a Document panel.
@@ -72,6 +78,12 @@ public class CompositionJPanel extends JPanel{
         }
         this.setToolTipText("<html>Holding <strong>Alt Gr</strong> : resize the representation of the element.<br/>" +
                 "Holding <strong>Shift</strong> : resire the element and keeps the ratio width/height.</html>");
+
+        waitLayer = new WaitLayerUI();
+        JLayer<JPanel> layer = new JLayer<>(panel, waitLayer);
+        this.add(layer);
+        /*this.revalidate();
+        this.repaint();*/
     }
     
     /**
@@ -86,21 +98,23 @@ public class CompositionJPanel extends JPanel{
         final int maxWidth = Math.max((int)newWidth, ge.getWidth());
         final int maxHeight = Math.max((int)newHeight, ge.getHeight());
 
-        this.removeAll();
+        panel.removeAll();
         //Add the BufferedImage into a JComponent in the CompositionJPanel
-        this.add(new JComponent() {
+        panel.add(new JComponent() {
             //Redefinition of the painComponent method to rotate the component content.
             @Override
             protected void paintComponent(Graphics g) {
                 super.paintComponent(g);
-                g.drawImage(bufferedImage, -(maxWidth-(int)newWidth)/2, -(maxHeight-(int)newHeight)/2, null);
+                g.drawImage(bufferedImage, -(maxWidth - (int) newWidth) / 2, -(maxHeight - (int) newHeight) / 2, null);
             }
         }, BorderLayout.CENTER);
+        panel.revalidate();
         this.revalidate();
         //As the buffered image is rotated, change the origin point of the panel to make the center of the image not moving after the rotation.
         //Take account of the border width (2 pixels).
-        this.setBounds(ge.getX() + (ge.getWidth()-(int)newWidth)/2, ge.getY()+(ge.getHeight()-(int)newHeight)/2, (int)newWidth+2, (int)newHeight+2);
+        this.setBounds(ge.getX() + (ge.getWidth() - (int) newWidth) / 2, ge.getY() + (ge.getHeight() - (int) newHeight) / 2, (int) newWidth + 2, (int) newHeight + 2);
         this.setOpaque(false);
+        panel.setOpaque(false);
         setBorders();
     }
 
@@ -114,7 +128,11 @@ public class CompositionJPanel extends JPanel{
            this.setBorder(BorderFactory.createLineBorder(Color.LIGHT_GRAY));
     }
 
-    /**
+    public WaitLayerUI getWaitLayer() {
+        return waitLayer;
+    }
+
+     /**
      * Select or unselect the panel on click.
      * @param me Mouse Event.
      */

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/RenderWorker.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/RenderWorker.java
@@ -1,0 +1,52 @@
+package org.orbisgis.mapcomposer.view.utils;
+
+import org.orbisgis.mapcomposer.controller.UIController;
+import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GraphicalElement;
+import org.orbisgis.mapcomposer.view.graphicalelement.GERenderer;
+
+import javax.swing.*;
+import java.awt.image.BufferedImage;
+
+/**
+ * This class extends the SwingWorker and is used to do the rendering of a GraphicalElement without freezing the MapComposer.
+ */
+public class RenderWorker extends SwingWorker{
+
+    private UIController uic;
+    private CompositionJPanel compPanel;
+    private GERenderer geRenderer;
+    private GraphicalElement ge;
+    private BufferedImage waitBI;
+
+    /**
+     * Main Constructor
+     * @param uic
+     * @param compPanel CompositionPanel where the GraphicalElement should be rendered.
+     * @param geRenderer Renderer to use to render the GraphicalElement.
+     * @param ge GraphicalElement to render
+     */
+    public RenderWorker(UIController uic, CompositionJPanel compPanel, GERenderer geRenderer, GraphicalElement ge){
+        this.uic = uic;
+        this.compPanel = compPanel;
+        this.geRenderer = geRenderer;
+        this.ge = ge;
+        this.waitBI = new BufferedImage(ge.getWidth(), ge.getHeight(), BufferedImage.TYPE_INT_ARGB);
+    }
+
+
+    @Override
+    protected Object doInBackground() throws Exception {
+        //Display the wait layer in the CompositionJPanel
+        compPanel.getWaitLayer().start();
+        compPanel.setPanelContent(geRenderer.createImageFromGE(ge));
+        //Hide the wait layer in the CompositionJPanel
+        compPanel.getWaitLayer().stop();
+        return null;
+    }
+
+    @Override
+    protected void done() {
+        uic.getMainWindow().getCompositionArea().refresh();
+    }
+}
+

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/RenderWorker.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/RenderWorker.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -30,6 +33,8 @@ import java.awt.image.BufferedImage;
 
 /**
  * This class extends the SwingWorker and is used to do the rendering of a GraphicalElement without freezing the MapComposer.
+ *
+ * @author Sylvain PALOMINOS
  */
 public class RenderWorker extends SwingWorker{
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/RenderWorker.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/RenderWorker.java
@@ -39,7 +39,7 @@ public class RenderWorker extends SwingWorker{
         compPanel.getWaitLayer().start();
         BufferedImage bi = geRenderer.createImageFromGE(ge);
         if(!isCancelled()) {
-            compPanel.setPanelContent(bi);
+            compPanel.redraw(ge.getX(), ge.getY(), ge.getWidth(), ge.getHeight(), ge.getRotation(), bi);
             compPanel.getWaitLayer().stop();
         }
         return null;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/RenderWorker.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/RenderWorker.java
@@ -16,7 +16,6 @@ public class RenderWorker extends SwingWorker{
     private CompositionJPanel compPanel;
     private GERenderer geRenderer;
     private GraphicalElement ge;
-    private BufferedImage waitBI;
 
     /**
      * Main Constructor
@@ -30,23 +29,25 @@ public class RenderWorker extends SwingWorker{
         this.compPanel = compPanel;
         this.geRenderer = geRenderer;
         this.ge = ge;
-        this.waitBI = new BufferedImage(ge.getWidth(), ge.getHeight(), BufferedImage.TYPE_INT_ARGB);
     }
 
 
     @Override
     protected Object doInBackground() throws Exception {
         //Display the wait layer in the CompositionJPanel
+        compPanel.setEnabled(false);
         compPanel.getWaitLayer().start();
-        compPanel.setPanelContent(geRenderer.createImageFromGE(ge));
-        //Hide the wait layer in the CompositionJPanel
-        compPanel.getWaitLayer().stop();
+        BufferedImage bi = geRenderer.createImageFromGE(ge);
+        if(!isCancelled()) {
+            compPanel.setPanelContent(bi);
+            compPanel.getWaitLayer().stop();
+        }
         return null;
     }
 
     @Override
     protected void done() {
-        uic.getMainWindow().getCompositionArea().refresh();
+        compPanel.setEnabled(true);
     }
 }
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/RenderWorker.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/RenderWorker.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.view.utils;
 
 import org.orbisgis.mapcomposer.controller.UIController;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/RenderWorker.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/RenderWorker.java
@@ -12,25 +12,21 @@ import java.awt.image.BufferedImage;
  */
 public class RenderWorker extends SwingWorker{
 
-    private UIController uic;
     private CompositionJPanel compPanel;
     private GERenderer geRenderer;
     private GraphicalElement ge;
 
     /**
      * Main Constructor
-     * @param uic
      * @param compPanel CompositionPanel where the GraphicalElement should be rendered.
      * @param geRenderer Renderer to use to render the GraphicalElement.
      * @param ge GraphicalElement to render
      */
-    public RenderWorker(UIController uic, CompositionJPanel compPanel, GERenderer geRenderer, GraphicalElement ge){
-        this.uic = uic;
+    public RenderWorker(CompositionJPanel compPanel, GERenderer geRenderer, GraphicalElement ge){
         this.compPanel = compPanel;
         this.geRenderer = geRenderer;
         this.ge = ge;
     }
-
 
     @Override
     protected Object doInBackground() throws Exception {
@@ -38,16 +34,10 @@ public class RenderWorker extends SwingWorker{
         compPanel.setEnabled(false);
         compPanel.getWaitLayer().start();
         BufferedImage bi = geRenderer.createImageFromGE(ge);
-        if(!isCancelled()) {
-            compPanel.redraw(ge.getX(), ge.getY(), ge.getWidth(), ge.getHeight(), ge.getRotation(), bi);
-            compPanel.getWaitLayer().stop();
-        }
-        return null;
-    }
-
-    @Override
-    protected void done() {
+        compPanel.redraw(ge.getX(), ge.getY(), ge.getWidth(), ge.getHeight(), ge.getRotation(), bi);
+        compPanel.getWaitLayer().stop();
         compPanel.setEnabled(true);
+        return null;
     }
 }
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.view.utils;
 
 import net.miginfocom.swing.MigLayout;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -33,6 +36,14 @@ import java.awt.event.ItemListener;
 import java.net.URL;
 import java.util.List;
 
+/**
+ * This class extends the UIPanel class an is used to display a popup windows allowing the user to configure GraphicalElements.
+ * It can be constructed in two ways :
+ * - By giving it the list of ConfigurationAttributes to configure and the class construct itself the displayed UI.
+ * - Adding one by one the different Components and ConfigurationAttributes corresponding to set.
+ *
+ * @author Sylvain PALOMINOS
+ */
 public class UIDialogProperties implements UIPanel {
 
     /** JPanel of the configuration elements. */

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/WaitLayerUI.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/WaitLayerUI.java
@@ -1,3 +1,24 @@
+/*
+* MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
+* documents based on OrbisGIS results.
+*
+* The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+* team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+*
+* Copyright (C) 2007-2014 IRSTV (FR CNRS 2488)
+*
+* This file is part of the MapComposer plugin.
+*
+* The MapComposer plugin is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* The MapComposer plugin is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details <http://www.gnu.org/licenses/>.
+*/
+
 package org.orbisgis.mapcomposer.view.utils;
 
 import javax.swing.*;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/WaitLayerUI.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/WaitLayerUI.java
@@ -1,0 +1,104 @@
+package org.orbisgis.mapcomposer.view.utils;
+
+import javax.swing.*;
+import javax.swing.plaf.LayerUI;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.beans.PropertyChangeEvent;
+
+/**
+ * This class extends the LayerUI an is used to show an animated image to indicate that the GraphicalElement rendering is running.
+ */
+class WaitLayerUI extends LayerUI<JPanel> implements ActionListener {
+    private boolean running;
+    private boolean fadingOut;
+
+    private final int countLimit = 15;
+    private int count;
+    private int angle;
+
+    private Timer timer;
+
+    public void start() {
+        if (!running) {
+            running = true;
+            fadingOut = false;
+            count = 0;
+            timer = new Timer(1000/24, this);
+            timer.start();
+        }
+    }
+
+    public void stop() {
+        fadingOut = true;
+    }
+
+    @Override
+    public void paint (Graphics g, JComponent c) {
+        int w = c.getWidth();
+        int h = c.getHeight();
+
+        // Paint the view.
+        super.paint (g, c);
+
+        if (!running) {
+            return;
+        }
+
+        Graphics2D g2 = (Graphics2D)g.create();
+        float fade = (float) count / (float) countLimit;
+        // Gray it out.
+        Composite urComposite = g2.getComposite();
+        g2.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, .5f * fade));
+        g2.fillRect(0, 0, w, h);
+        //g2.setComposite(urComposite);
+
+        // Paint the wait indicator.
+        int s = Math.min(w, h) / 5;
+        int cx = w / 2;
+        int cy = h / 2;
+        g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+                RenderingHints.VALUE_ANTIALIAS_ON);
+        g2.setStroke(
+                new BasicStroke(s / 4, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+        g2.setPaint(Color.white);
+        g2.rotate(Math.PI * angle / 180, cx, cy);
+        for (int i = 0; i < 12; i++) {
+            float scale = (11.0f - (float)i) / 11.0f;
+            g2.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, scale * fade));
+            g2.drawLine(cx + s, cy, cx + s * 2, cy);
+            g2.rotate(-Math.PI / 6, cx, cy);
+        }
+
+        g2.dispose();
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        if (running) {
+            if (fadingOut) {
+                if (count == 0) {
+                    running = false;
+                    timer.stop();
+                }
+                else
+                    count--;
+            }
+            else if (count < countLimit) {
+                count++;
+            }
+
+            angle += 3;
+            angle %=360;
+
+            firePropertyChange("tick", 0, 1);
+        }
+    }
+
+    @Override
+    public void applyPropertyChange(PropertyChangeEvent pce, JLayer l) {
+        if ("tick".equals(pce.getPropertyName())) {
+            l.repaint();
+        }
+    }
+}

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/WaitLayerUI.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/WaitLayerUI.java
@@ -2,6 +2,9 @@
 * MapComposer is an OrbisGIS plugin dedicated to the creation of cartographic
 * documents based on OrbisGIS results.
 *
+* This plugin is developed at French IRSTV institute as part of the MApUCE project,
+* funded by the French Agence Nationale de la Recherche (ANR) under contract ANR-13-VBDU-0004.
+*
 * The MapComposer plugin is distributed under GPL 3 license. It is produced by the "Atelier SIG"
 * team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
 *
@@ -30,6 +33,8 @@ import java.beans.PropertyChangeEvent;
 
 /**
  * This class extends the LayerUI an is used to show an animated image to indicate that the GraphicalElement rendering is running.
+ *
+ * @author Sylvain PALOMINOS
  */
 public class WaitLayerUI extends LayerUI<JPanel> implements ActionListener {
     private boolean running;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/WaitLayerUI.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/WaitLayerUI.java
@@ -10,7 +10,7 @@ import java.beans.PropertyChangeEvent;
 /**
  * This class extends the LayerUI an is used to show an animated image to indicate that the GraphicalElement rendering is running.
  */
-class WaitLayerUI extends LayerUI<JPanel> implements ActionListener {
+public class WaitLayerUI extends LayerUI<JPanel> implements ActionListener {
     private boolean running;
     private boolean fadingOut;
 


### PR DESCRIPTION
Adds the usage of swing workers for the GraphicalElement rendering.
Now the GE will be rendered only on their creation (including loading an existing project) and just before exporting the document.
Only one element can be rendered at the same time and during this time the CompositionJPanel of the GE is disabled to avoid its edition.

Now, on the creation of a GraphicalElement, the user must first configure it in the configuration dialog, before drawing it in the CompositionArea.

Some improvement are done : 
- Decrease of the number of render calling. Once drawn, the CompositionJPanel handle a BufferedImage that increase the speed of the application.
- Corrects the behaviour of the JSpinners in the tool bar.
- Unselects all the GE on clicking outside of the document.
- Fixes the issues #17 and #18 about window location on the screen.
- Fixes the issue #21 about the MapComposer icon.
- Also fixes the issue #15 and the issue #19 which was already fixed.